### PR TITLE
docs: add complete project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,196 @@
-<div align="center">
+# Mergington High School Activities API
 
-# 🎉 Congratulations akhileshekartha! 🎉
+FastAPI application for managing school extracurricular activities, with a browser UI for teachers to register and unregister students.
 
-<img src="https://octodex.github.com/images/welcometocat.png" height="200px" />
+## Table of Contents
 
-### 🌟 You've successfully completed the exercise! 🌟
+- [Overview](#overview)
+- [Features](#features)
+- [Project Structure](#project-structure)
+- [Requirements](#requirements)
+- [Quick Start](#quick-start)
+- [Teacher Authentication](#teacher-authentication)
+- [API Reference](#api-reference)
+- [Example Requests](#example-requests)
+- [Frontend UI](#frontend-ui)
+- [Data and Persistence](#data-and-persistence)
+- [Troubleshooting](#troubleshooting)
 
-## 🚀 Share Your Success!
+## Overview
 
-**Show off your new skills and inspire others!**
+This project exposes an activities API and serves a small web interface from the same FastAPI app. Teachers can log in, then register or unregister student emails for each activity.
 
-<a href="https://twitter.com/intent/tweet?text=I%20just%20completed%20the%20%22Integrate%20MCP%20with%20GitHub%20Copilot%22%20GitHub%20Skills%20hands-on%20exercise!%20%F0%9F%8E%89%0A%0Ahttps%3A%2F%2Fgithub.com%2Fakhileshekartha%2Fskills-integrate-mcp-with-copilot%0A%0A%23GitHubSkills%20%23OpenSource%20%23GitHubLearn" target="_blank" rel="noopener noreferrer">
-  <img src="https://img.shields.io/badge/Share%20on%20X-1da1f2?style=for-the-badge&logo=x&logoColor=white" alt="Share on X" />
-</a>
-<a href="https://bsky.app/intent/compose?text=I%20just%20completed%20the%20%22Integrate%20MCP%20with%20GitHub%20Copilot%22%20GitHub%20Skills%20hands-on%20exercise!%20%F0%9F%8E%89%0A%0Ahttps%3A%2F%2Fgithub.com%2Fakhileshekartha%2Fskills-integrate-mcp-with-copilot%0A%0A%23GitHubSkills%20%23OpenSource%20%23GitHubLearn" target="_blank" rel="noopener noreferrer">
-  <img src="https://img.shields.io/badge/Share%20on%20Bluesky-0085ff?style=for-the-badge&logo=bluesky&logoColor=white" alt="Share on Bluesky" />
-</a>
-<a href="https://www.linkedin.com/feed/?shareActive=true&text=I%20just%20completed%20the%20%22Integrate%20MCP%20with%20GitHub%20Copilot%22%20GitHub%20Skills%20hands-on%20exercise!%20%F0%9F%8E%89%0A%0Ahttps%3A%2F%2Fgithub.com%2Fakhileshekartha%2Fskills-integrate-mcp-with-copilot%0A%0A%23GitHubSkills%20%23OpenSource%20%23GitHubLearn" target="_blank" rel="noopener noreferrer">
-  <img src="https://img.shields.io/badge/Share%20on%20LinkedIn-0077b5?style=for-the-badge&logo=linkedin&logoColor=white" alt="Share on LinkedIn" />
-</a>
+## Features
 
-### 🎯 What's Next?
+- List all activities and current participants
+- Teacher login and logout using token-based auth
+- Register a student for an activity
+- Unregister a student from an activity
+- Built-in static frontend at `/static/index.html`
+- Automatic root redirect from `/` to the web UI
 
-**Keep the momentum going!**
+## Project Structure
 
-[![](https://img.shields.io/badge/Return%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/akhileshekartha/skills-integrate-mcp-with-copilot/issues/1)
-[![GitHub Skills](https://img.shields.io/badge/Explore%20GitHub%20Skills-000000?style=for-the-badge&logo=github&logoColor=white)](https://learn.github.com/skills)
+```
+.
+|-- README.md
+|-- requirements.txt
+`-- src
+    |-- app.py
+    |-- teachers.json
+    |-- README.md
+    `-- static
+        |-- index.html
+        |-- app.js
+        `-- styles.css
+```
 
-*There's no better way to learn than building things!* 🚀
+## Requirements
 
-</div>
+- Python 3.10+
+- pip
 
----
+Dependencies are listed in `requirements.txt`:
 
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+- fastapi
+- uvicorn
+
+## Quick Start
+
+1. Clone the repository.
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Start the app from the repository root:
+
+```bash
+uvicorn src.app:app --reload
+```
+
+4. Open:
+
+- Frontend UI: http://localhost:8000/
+- Swagger docs: http://localhost:8000/docs
+- ReDoc: http://localhost:8000/redoc
+
+## Teacher Authentication
+
+- Login endpoint returns a token.
+- Protected endpoints require the `X-Teacher-Token` header.
+- The frontend stores the token in browser local storage.
+
+Teacher accounts for local testing are defined in `src/teachers.json`.
+
+## API Reference
+
+### `GET /activities`
+
+Returns all activities, including description, schedule, capacity, and participant emails.
+
+### `POST /auth/login`
+
+Logs in a teacher.
+
+Request body:
+
+```json
+{
+  "username": "teacher.alex",
+  "password": "mergington123"
+}
+```
+
+Success response:
+
+```json
+{
+  "message": "Login successful",
+  "token": "<generated_token>",
+  "username": "teacher.alex"
+}
+```
+
+### `POST /auth/logout`
+
+Logs out a teacher and invalidates the current token.
+
+Header:
+
+- `X-Teacher-Token: <token>`
+
+### `POST /activities/{activity_name}/signup?email={student_email}`
+
+Registers a student for an activity.
+
+Header:
+
+- `X-Teacher-Token: <token>`
+
+### `DELETE /activities/{activity_name}/unregister?email={student_email}`
+
+Unregisters a student from an activity.
+
+Header:
+
+- `X-Teacher-Token: <token>`
+
+## Example Requests
+
+Login and save token:
+
+```bash
+curl -X POST "http://localhost:8000/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"teacher.alex","password":"mergington123"}'
+```
+
+Get activities:
+
+```bash
+curl "http://localhost:8000/activities"
+```
+
+Register a student:
+
+```bash
+curl -X POST "http://localhost:8000/activities/Chess%20Club/signup?email=student@mergington.edu" \
+  -H "X-Teacher-Token: <token>"
+```
+
+Unregister a student:
+
+```bash
+curl -X DELETE "http://localhost:8000/activities/Chess%20Club/unregister?email=student@mergington.edu" \
+  -H "X-Teacher-Token: <token>"
+```
+
+## Frontend UI
+
+The app serves a simple teacher-facing UI from `src/static`:
+
+- `index.html`: layout and modals
+- `app.js`: API calls, auth state, register/unregister actions
+- `styles.css`: page and component styling
+
+When not logged in, registration and removal actions are blocked.
+
+## Data and Persistence
+
+- Activity data is held in memory in `src/app.py`.
+- Teacher sessions (tokens) are also in memory.
+- Restarting the server resets activity participants and active sessions.
+
+## Troubleshooting
+
+- `ModuleNotFoundError`: install dependencies with `pip install -r requirements.txt`.
+- Port already in use: free port `8000` or run with `uvicorn src.app:app --reload --port 8001`.
+- `401 Teacher authentication required`: pass a valid `X-Teacher-Token`.
+- `404 Activity not found`: verify `activity_name` and URL encoding.
+
+## License
+
+This project is licensed under the MIT License. See `LICENSE` for details.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,50 +1,46 @@
-# Mergington High School Activities API
+# Source Folder Guide
 
-A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
+This directory contains the runnable FastAPI service and static frontend.
 
-## Features
+## Contents
 
-- View all available extracurricular activities
-- Sign up for activities
+- `app.py`: FastAPI app, in-memory activities data, and authentication endpoints
+- `teachers.json`: local teacher credentials used by the login endpoint
+- `static/index.html`: frontend page
+- `static/app.js`: frontend behavior for login, registration, and unregister actions
+- `static/styles.css`: frontend styling
 
-## Getting Started
+## Run from this Folder
 
-1. Install the dependencies:
+Install dependencies from the repository root or this folder:
 
-   ```
-   pip install fastapi uvicorn
-   ```
+```bash
+pip install -r ../requirements.txt
+```
 
-2. Run the application:
+Start the app:
 
-   ```
-   python app.py
-   ```
+```bash
+uvicorn app:app --reload
+```
 
-3. Open your browser and go to:
-   - API documentation: http://localhost:8000/docs
-   - Alternative documentation: http://localhost:8000/redoc
+Open:
 
-## API Endpoints
+- UI: http://localhost:8000/
+- Swagger: http://localhost:8000/docs
 
-| Method | Endpoint                                                          | Description                                                         |
-| ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+## Auth Notes
 
-## Data Model
+- Login: `POST /auth/login`
+- Logout: `POST /auth/logout`
+- Protected actions require `X-Teacher-Token`
 
-The application uses a simple data model with meaningful identifiers:
+Protected endpoints:
 
-1. **Activities** - Uses activity name as identifier:
+- `POST /activities/{activity_name}/signup?email=...`
+- `DELETE /activities/{activity_name}/unregister?email=...`
 
-   - Description
-   - Schedule
-   - Maximum number of participants allowed
-   - List of student emails who are signed up
+## Important Behavior
 
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
-
-All data is stored in memory, which means data will be reset when the server restarts.
+- Data is in-memory only.
+- Restarting the app clears active login sessions and activity changes.


### PR DESCRIPTION
## Summary
- replace placeholder root README with full project documentation
- document setup, run instructions, auth flow, API endpoints, and curl examples
- add source-folder guide in `src/README.md` aligned with current code behavior
- include troubleshooting and data persistence notes

## Why
The repository previously had a completion banner in the root README and incomplete API documentation. This PR adds practical documentation for contributors and users.

## Validation
- reviewed endpoint behavior against `src/app.py`
- confirmed startup commands use Uvicorn entrypoints